### PR TITLE
Expand CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,16 @@ jobs:
         sanitizer:
           - asan
           - tsan
+          - ""
         os: [ ubuntu-latest ]
-        build_type: [ Release ]
+        build_type:
+          - Debug
+          - Release
 
         include:
+          - preset: msvc
+            os: windows-latest
+            build_type: Debug
           - preset: msvc
             os: windows-latest
             build_type: Release

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ corofx_add_test(test_move CoroFX)
 corofx_add_test(test_nested CoroFX)
 # GCC 13.3.0 seems to have some issues with symmetric transfer when sanitizers are enabled.
 # Likely https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100897.
-if (NOT (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" AND (${COROFX_ENABLE_ASAN} OR ${COROFX_ENABLE_TSAN})))
+if (NOT (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" AND (${CMAKE_BUILD_TYPE} STREQUAL "Debug" OR ${COROFX_ENABLE_ASAN} OR ${COROFX_ENABLE_TSAN})))
     corofx_add_test(test_recursive CoroFX)
 endif()
 corofx_add_test(test_type_set CoroFX)


### PR DESCRIPTION
- Expand CI matrix to include debug and non-sanitizer builds